### PR TITLE
fixed bug: return 404 when request scripts/controllers/somePage.js

### DIFF
--- a/app/templates/module/manifest.json
+++ b/app/templates/module/manifest.json
@@ -10,7 +10,7 @@
   "scripts": [
     "scripts/initNgModule.js",
     "scripts/controllers/main.js",
-    "scripts/controllers/somepage.js",
+    "scripts/controllers/somePage.js",
     "scripts/initWebModule.js"
   ],
   "styles": [


### PR DESCRIPTION
На Linux-системе не подгружается файл http://localhost/modules/module_name/scripts/controllers/somepage.js из-за того, что в manifest-файле указана неправильная ссылка на файл.